### PR TITLE
DID integration

### DIFF
--- a/DID.as
+++ b/DID.as
@@ -1,0 +1,17 @@
+#if DEPENDENCY_DID
+class PredictorProvider : DID::LaneProvider {
+    DID::LaneProviderSettings@ getProviderSetup() {
+        DID::LaneProviderSettings settings;
+        settings.author = "JackNytely";
+        settings.internalName = "Predictor/TimeString";
+        settings.friendlyName = "Predictor - Predicted time";
+        return settings;
+    }
+
+    DID::LaneConfig@ getLaneConfig(DID::LaneConfig@ &in defaults) {
+        DID::LaneConfig c = defaults;
+        c.content = predictedTimeString;
+        return c;
+    }
+}
+#endif

--- a/Predictor.as
+++ b/Predictor.as
@@ -34,6 +34,12 @@ array<string> compareCPSplitArray;
 string curFontFace = "";
 nvg::Font font;
 
+void Main() {
+#if DEPENDENCY_DID
+	DID::registerLaneProviderAddon(PredictorProvider());
+#endif
+}
+
 void Render() {
 	if(showTimer && NytelyLib::inGame) {
 		string text = predictedTimeString;

--- a/info.toml
+++ b/info.toml
@@ -5,3 +5,5 @@ category = "Utilities"
 siteid = 160
 version = "2.0"
 
+[script]
+optional_dependencies = ["DID"]


### PR DESCRIPTION
adds [DID](https://openplanet.dev/plugin/did) as an optional dependency and exports `predictedTimeString` as a lane provider.

![image](https://github.com/JackNytely/TMNext-Predictor/assets/2791628/538ce4f4-3e1b-4421-831c-1f11114fc784)
